### PR TITLE
Fix inkscape option for pdf-export

### DIFF
--- a/emoji_filter.js
+++ b/emoji_filter.js
@@ -37,7 +37,7 @@ function imageSourceGenerator(icon, options) {
 function svg_to_pdf(src) {
 	const full_target = path.join(process.cwd(), src.replace(/\.svg$/, ".pdf"))
 	const full_src = path.join(process.cwd(), src)
-	const cmd_line = `"${inkscape_path}" --export-pdf "${full_target}" "${full_src}"`
+	const cmd_line = `"${inkscape_path}" --export-type=pdf "${full_target}" "${full_src}"`
 	if (!fs.existsSync(full_target))
 		shell.exec(cmd_line)
 	return full_target


### PR DESCRIPTION
I've got the following error while using your filter with pandoc:
```
Unknown option --export-pdf
```
This leads to errors while generating the final pdf-file because pandoc can't find the emoji-pdf-files inkscape should export.

According to the [Inkscape man-page](https://inkscape.org/doc/inkscape-man.html) the correct option for exporting pdf is `--export-type=pdf`

With my fix the error-message doesn't appear anymore and the emoji-pdf-files are correctly exported by inkscape and therefore pandoc generates the final pdf-file correctly.