### PR TITLE
Remove inkscape dep

### DIFF
--- a/emoji_filter.js
+++ b/emoji_filter.js
@@ -22,13 +22,13 @@ const https = require('https')
 const twemoji = require('twemoji')
 const shell = require('shelljs')
 const path = require('path')
+const PDFDocument = require('pdfkit')
+const SVGtoPDF = require('svg-to-pdfkit')
 
 function wait_debugger() {
 	var hr=process.hrtime.bigint,f=wait_debugger,t
 	while(!f._r){t=hr();debugger;if(hr()-t>100000000)f._r=true}
 }
-
-const inkscape_path = shell.which("inkscape").stdout.split("\n")[0].trim()
 
 function imageSourceGenerator(icon, options) {
 	return icon
@@ -37,9 +37,14 @@ function imageSourceGenerator(icon, options) {
 function svg_to_pdf(src) {
 	const full_target = path.join(process.cwd(), src.replace(/\.svg$/, ".pdf"))
 	const full_src = path.join(process.cwd(), src)
-	const cmd_line = `"${inkscape_path}" --export-type=pdf "${full_target}" "${full_src}"`
-	if (!fs.existsSync(full_target))
-		shell.exec(cmd_line)
+	const doc = new PDFDocument()
+	const svg = fs.readFileSync(full_src).toString()
+	const stream = fs.createWriteStream(full_target)
+	SVGtoPDF(doc, svg)
+	
+	doc.pipe(stream)
+	doc.end()
+	
 	return full_target
 }
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "pandoc-emoji-filter",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Replaces unicode emoji codepoints to SVG representations so that they are displayed inside the resulting PDF",
   "main": "create-example.sh",
   "dependencies": {
     "pandoc-filter": "^2.0.0",
     "shelljs": "^0.8.4",
-    "twemoji": "^12.1.5"
+    "twemoji": "^12.1.5",
+    "pdfkit": "^0.13.0",
+    "svg-to-pdfkit": "^0.1.8"
   },
   "devDependencies": {},
   "scripts": {
@@ -22,7 +24,8 @@
     "svg",
     "markdown",
     "pdf",
-    "filter"
+    "filter",
+    "pdfkit"
   ],
   "author": "Miguel Angelo Santos Bicudo (masbicudo@gmail.com)",
   "license": "Apache-2.0",


### PR DESCRIPTION
This should give a more universal solution without requiring additional software to be installed. Tested on Win10 with the lastest versions of pdfkit and svg-to-pdfkit at the time.

I tested the solution and it works fine, but because the testing occurred on my work computer, I was unable to copy/paste the code and had to retype. I've gone over it a few times, but there is a chance that there is a typo.